### PR TITLE
Move db fixture to the inside of the method

### DIFF
--- a/pytest_django_haystack.py
+++ b/pytest_django_haystack.py
@@ -13,7 +13,7 @@ def pytest_configure(config):
 
 
 @pytest.fixture(autouse=True)
-def _haystack_marker(request, db):
+def _haystack_marker(request):
     """
     Implement the 'haystack' marker.
 
@@ -24,6 +24,7 @@ def _haystack_marker(request, db):
     if marker:
         from pytest_django.lazy_django import skip_if_no_django
         from django.core.management import call_command
+        request.getfuncargvalue('db')
 
         def clear_index():
             call_command('clear_index', interactive=False)


### PR DESCRIPTION
I noticed when trying to have some tests faster, that I always need a connection to the database.
I then realized it is because of the haystack fixture which gets always applied and has a dependency to the db fixture which now also always gets applied.
By moving the requirement this way, I can still have tests that run without a DB.
I copied this way of getting the db from the django_pytest package, where they do it in similar fashion