### PR TITLE
Add an option to specify haystack connection to be used

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -8,3 +8,9 @@ Quick start
 
 1. ``pip install pytest-django-haystack``
 2. Mark tests with the ``pytest.mark.haystack`` marker.
+
+
+You can optionally specify which haystack connection(s) should be used::
+
+    @pytest.mark.haystack(connection=["test"])
+


### PR DESCRIPTION
The old syntax still works, this just adds an option if you want to specify a particular haystack connection.